### PR TITLE
Fix a typo

### DIFF
--- a/bevy-cheatsheet.md
+++ b/bevy-cheatsheet.md
@@ -119,7 +119,7 @@ fn manager_system(mut cmd: Commands, data: Res<MyRes>, mut q: Query<(Entity, &St
 
 ## For-each systems
 
-Special kind of system to offer simpler syntax for iterating over a single query. Can still have resources and commands.
+Special kind of system to offer simpler syntax for iterating over a single entity. Can still have resources and commands.
 
 The query is handled internally by Bevy and the system is called for each entity with the given components.
 


### PR DESCRIPTION
“For-each systems” section mentioned “iterating over a single query” instead of “iterating over a single entity”.